### PR TITLE
Support request headers

### DIFF
--- a/src/httpclient.js
+++ b/src/httpclient.js
@@ -8,6 +8,7 @@ var http = require('http'),
  *                      host ('localhost')
  *                      port (80)
  *                      path ('')       - Base path URL e.g. '/api'
+ *                      reqHeaders ({}) - Headers to send with every request.
  *                      headers ({})    - Test that these headers are present on every response (unless overridden)
  *                      status (null)   - Test that every response has this status (unless overridden)
  */
@@ -18,6 +19,7 @@ var HttpClient = module.exports = function(options) {
     this.port = options.port || 80;
     this.path = options.path || '';
     this.headers = options.headers || {};
+    this.reqHeaders = options.reqHeaders || {};
     this.status = options.status;
 }
 
@@ -100,7 +102,9 @@ methods.forEach(function(method) {
 
             if (data) {
                 if (typeof data == 'object') {
-                    request.setHeader('content-type', 'application/json');
+                    if (typeof this.reqHeaders['content-type'] === 'undefined') {
+                      request.setHeader('content-type', 'application/json');
+                    }
                     request.write(JSON.stringify(data));
                 } else {
                     request.write(data);


### PR DESCRIPTION
Some APIs use the `accept` header to negotiate the correct version to serve but it doesn't appear to be possible to set this during instantiation. Furthermore, nodeunit-httpclient assumes that if the data for a request is an object the `content-type` header should be `application/json` and not necessarily whatever the `Accept` header is set to. This PR allows the client to be instantiated with an appropriate `content-type` request header and prevents overriding the header with `application/json` if it has already been set.
